### PR TITLE
Update README.md to include install of electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ In order to reset the viewer, you'll have to click "window->reload".
 # Getting Started
 
 * Install [Node.js](https://nodejs.org/en/)
+* Install Electron: npm install --save-dev electron@latest
 * Execute PotreeDesktop.bat
 * Drag and Drop a las or laz file to convert and load it.
 * Drag and Drop a previously converted point cloud to load it. 


### PR DESCRIPTION
When following the instructions naively, an error can occur where Electron is not found. This is remedied by installing Electron.  Adding this to the instructions improves reaching users that are easily lost.